### PR TITLE
Acceptable ConnectorProfile's properties extended.

### DIFF
--- a/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/InPortPahoSubSecure.py
+++ b/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/InPortPahoSubSecure.py
@@ -194,6 +194,21 @@ class InPortPahoSubSecure(OpenRTM_aist.InPortProvider, PahoSubSecure):
     return False
 
   ##
+  # @brief Find index of the from properties
+  #
+  # acceptable properties:
+  #     {<key>, dataport.<key>, dataport.inport.<key>}
+  #
+  def findProp(self, properties, key):
+    index = OpenRTM_aist.NVUtil.find_index(properties, key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.' + key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.inport.' + key)
+    if index >= 0: return index
+    return -1
+
+  ##
   # @brief Set properties relating to Paho Client
   #
   def subscribePahoSubSecure(self, properties):
@@ -210,16 +225,16 @@ class InPortPahoSubSecure(OpenRTM_aist.InPortProvider, PahoSubSecure):
     PN_CLTCERT = "cltcert"
     PN_CLTKEY = "cltkey"
 
-    index0 = OpenRTM_aist.NVUtil.find_index(properties, PN_HOST)
-    index1 = OpenRTM_aist.NVUtil.find_index(properties, PN_PORT)
-    index2 = OpenRTM_aist.NVUtil.find_index(properties, PN_KPALV)
-    index3 = OpenRTM_aist.NVUtil.find_index(properties, PN_TOPIC)
-    index4 = OpenRTM_aist.NVUtil.find_index(properties, PN_QOS)
-    index5 = OpenRTM_aist.NVUtil.find_index(properties, PN_ID)
-    index6 = OpenRTM_aist.NVUtil.find_index(properties, PN_CS)
-    index7 = OpenRTM_aist.NVUtil.find_index(properties, PN_CACERT)
-    index8 = OpenRTM_aist.NVUtil.find_index(properties, PN_CLTCERT)
-    index9 = OpenRTM_aist.NVUtil.find_index(properties, PN_CLTKEY)
+    index0 = self.findProp(properties, PN_HOST)
+    index1 = self.findProp(properties, PN_PORT)
+    index2 = self.findProp(properties, PN_KPALV)
+    index3 = self.findProp(properties, PN_TOPIC)
+    index4 = self.findProp(properties, PN_QOS)
+    index5 = self.findProp(properties, PN_ID)
+    index6 = self.findProp(properties, PN_CS)
+    index7 = self.findProp(properties, PN_CACERT)
+    index8 = self.findProp(properties, PN_CLTCERT)
+    index9 = self.findProp(properties, PN_CLTKEY)
 
     tmp_host = "localhost"
     tmp_port = 8883

--- a/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/InPortPahoSubscriber.py
+++ b/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/InPortPahoSubscriber.py
@@ -194,6 +194,21 @@ class InPortPahoSubscriber(OpenRTM_aist.InPortProvider, PahoSubscriber):
     return False
 
   ##
+  # @brief Find index of the from properties
+  #
+  # acceptable properties:
+  #     {<key>, dataport.<key>, dataport.inport.<key>}
+  #
+  def findProp(self, properties, key):
+    index = OpenRTM_aist.NVUtil.find_index(properties, key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.' + key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.inport.' + key)
+    if index >= 0: return index
+    return -1
+
+  ##
   # @brief Set properties relating to Paho Client
   #
   def subscribePahoSubscriber(self, properties):
@@ -207,13 +222,15 @@ class InPortPahoSubscriber(OpenRTM_aist.InPortProvider, PahoSubscriber):
     PN_ID = "id"
     PN_CS = "cs"
 
-    index0 = OpenRTM_aist.NVUtil.find_index(properties, PN_HOST)
-    index1 = OpenRTM_aist.NVUtil.find_index(properties, PN_PORT)
-    index2 = OpenRTM_aist.NVUtil.find_index(properties, PN_KPALV)
-    index3 = OpenRTM_aist.NVUtil.find_index(properties, PN_TOPIC)
-    index4 = OpenRTM_aist.NVUtil.find_index(properties, PN_QOS)
-    index5 = OpenRTM_aist.NVUtil.find_index(properties, PN_ID)
-    index6 = OpenRTM_aist.NVUtil.find_index(properties, PN_CS)
+    index0 = self.findProp(properties, PN_HOST)
+    index1 = self.findProp(properties, PN_PORT)
+    index2 = self.findProp(properties, PN_KPALV)
+    index3 = self.findProp(properties, PN_TOPIC)
+    index4 = self.findProp(properties, PN_QOS)
+    index5 = self.findProp(properties, PN_ID)
+    index6 = self.findProp(properties, PN_CS)
+
+
 
     tmp_host = "localhost"
     tmp_port = 1883

--- a/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/OutPortPahoPubSecure.py
+++ b/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/OutPortPahoPubSecure.py
@@ -132,6 +132,21 @@ class OutPortPahoPubSecure(OpenRTM_aist.InPortConsumer, PahoPubSecure):
     return
 
   ##
+  # @brief Find index of the from properties
+  #
+  # acceptable properties:
+  #     {<key>, dataport.<key>, dataport.outport.<key>}
+  #
+  def findProp(self, properties, key):
+    index = OpenRTM_aist.NVUtil.find_index(properties, key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.' + key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.outport.' + key)
+    if index >= 0: return index
+    return -1
+
+  ##
   # @brief Set properties relating to Paho Client
   #
   def subscribePahoPubSecure(self, properties):
@@ -148,16 +163,16 @@ class OutPortPahoPubSecure(OpenRTM_aist.InPortConsumer, PahoPubSecure):
     PN_CLTCERT = "cltcert"
     PN_CLTKEY = "cltkey"
 
-    index0 = OpenRTM_aist.NVUtil.find_index(properties, PN_HOST)
-    index1 = OpenRTM_aist.NVUtil.find_index(properties, PN_PORT)
-    index2 = OpenRTM_aist.NVUtil.find_index(properties, PN_KPALV)
-    index3 = OpenRTM_aist.NVUtil.find_index(properties, PN_TOPIC)
-    index4 = OpenRTM_aist.NVUtil.find_index(properties, PN_QOS)
-    index5 = OpenRTM_aist.NVUtil.find_index(properties, PN_ID)
-    index6 = OpenRTM_aist.NVUtil.find_index(properties, PN_CS)
-    index7 = OpenRTM_aist.NVUtil.find_index(properties, PN_CACERT)
-    index8 = OpenRTM_aist.NVUtil.find_index(properties, PN_CLTCERT)
-    index9 = OpenRTM_aist.NVUtil.find_index(properties, PN_CLTKEY)
+    index0 = self.findProp(properties, PN_HOST)
+    index1 = self.findProp(properties, PN_PORT)
+    index2 = self.findProp(properties, PN_KPALV)
+    index3 = self.findProp(properties, PN_TOPIC)
+    index4 = self.findProp(properties, PN_QOS)
+    index5 = self.findProp(properties, PN_ID)
+    index6 = self.findProp(properties, PN_CS)
+    index7 = self.findProp(properties, PN_CACERT)
+    index8 = self.findProp(properties, PN_CLTCERT)
+    index9 = self.findProp(properties, PN_CLTKEY)
 
     tmp_host = "localhost"
     tmp_port = 8883

--- a/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/OutPortPahoPublisher.py
+++ b/OpenRTM_aist_v122l_paho_mqtt_interface/OpenRTM_aist_paho_mqtt_module/OutPortPahoPublisher.py
@@ -132,6 +132,21 @@ class OutPortPahoPublisher(OpenRTM_aist.InPortConsumer, PahoPublisher):
     return
 
   ##
+  # @brief Find index of the from properties
+  #
+  # acceptable properties:
+  #     {<key>, dataport.<key>, dataport.outport.<key>}
+  #
+  def findProp(self, properties, key):
+    index = OpenRTM_aist.NVUtil.find_index(properties, key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.' + key)
+    if index >= 0: return index
+    index = OpenRTM_aist.NVUtil.find_index(properties, 'dataport.outport.' + key)
+    if index >= 0: return index
+    return -1
+
+  ##
   # @brief Set properties relating to Paho Client
   #
   def subscribePahoPublisher(self, properties):
@@ -145,13 +160,13 @@ class OutPortPahoPublisher(OpenRTM_aist.InPortConsumer, PahoPublisher):
     PN_ID = "id"
     PN_CS = "cs"
 
-    index0 = OpenRTM_aist.NVUtil.find_index(properties, PN_HOST)
-    index1 = OpenRTM_aist.NVUtil.find_index(properties, PN_PORT)
-    index2 = OpenRTM_aist.NVUtil.find_index(properties, PN_KPALV)
-    index3 = OpenRTM_aist.NVUtil.find_index(properties, PN_TOPIC)
-    index4 = OpenRTM_aist.NVUtil.find_index(properties, PN_QOS)
-    index5 = OpenRTM_aist.NVUtil.find_index(properties, PN_ID)
-    index6 = OpenRTM_aist.NVUtil.find_index(properties, PN_CS)
+    index0 = self.findProp(properties, PN_HOST)
+    index1 = self.findProp(properties, PN_PORT)
+    index2 = self.findProp(properties, PN_KPALV)
+    index3 = self.findProp(properties, PN_TOPIC)
+    index4 = self.findProp(properties, PN_QOS)
+    index5 = self.findProp(properties, PN_ID)
+    index6 = self.findProp(properties, PN_CS)
 
     tmp_host = "localhost"
     tmp_port = 1883


### PR DESCRIPTION
paho_mqtt ポートに与える property ですが、現状トップレベルの名前空間なしの host, port, topic などのみを受け付けるようになっています。
本来データポートの property は dataport. の下、InPot/OutPort 特有のpropertyは dataport.inport/outport の下に来るように設計されていますので、トップレベル、dataport, dataport.inport/outport のいずれかで指定された場合にもpaho_mqttのConnectorProfileとして受け付けるように変更しました。

これによって、rtc.conf 内で、

```
manager.components.preactivation: ConsoleIn0
manager.components.preconnect: \
    ConsoleIn0.out?interface_type=paho_mqtt&host=localhost&topic=hoge
```

のように指定することで、起動時に自動的にMQTTブローカーにつなぎに行くように設定可能です。RTSystemEditorでいちいち指定しなくてもいいのでより便利になるかと思います。

ちなみに、*Secure.py の方にも同様の変更を行っていますが、こちらはテストできていません。マージいただければ幸甚です。
