### PR TITLE
Launch scripts for example RTCs with Paho MQTT interface

### DIFF
--- a/samples/SeqIO/SeqIn.sh
+++ b/samples/SeqIO/SeqIn.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+HOSTNAME="localhost"
+HOSTNAME="140.227.125.181"
+CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
+COMPNAME="SeqIn.py"
+
+comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
+comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
+
+############################################
+# Check RTC's path
+# RTC's path is set to "comp_path"
+if test "x" = "x$comp3_path" ; then
+    if test "x" = "x$comp2_path" ; then
+	echo "${COMPNAME} not found. Aborting."
+	exit 1
+    else
+	comp_path=${comp2_path}
+	python_cmd="python2"
+    fi
+else
+    comp_path=${comp3_path}
+    python_cmd="python3"
+fi
+
+############################################
+# Check Paho MQTT module
+# Paho MQTT module path is set to "mod_path" 
+if test "xpython3" = "x${python_cmd}" ; then
+    mod3_path=`pip3 show OpenRTM_aist_paho_mqtt_module | grep Location | awk '{print $2;}'`
+    if test "x" = "x${mod3_path}" ; then
+	echo "Paho MQTT module for OpenRTM-aist not found. Aborting."
+	exit 1
+    fi
+    mod_path=${mod3_path}/OpenRTM_aist_paho_mqtt_module
+elif test "xpython2" = "x${python_cmd}" ; then
+    mod2_path=`pip2 show OpenRTM_aist_paho_mqtt_module | grep Location | awk '{print $2;}'`
+    if test "x" = "x${mod2_path}" ; then
+	echo "Paho MQTT module for OpenRTM-aist not found. Aborting."
+	exit 1
+    fi
+    mod_path=${mod2_path}/OpenRTM_aist_paho_mqtt_module
+else
+    echo "Unknown error. (never comes here)"
+    exit 1
+fi
+echo "comp_path: " ${comp_path}
+echo "mod_path:  " ${mod_path}
+
+######################
+# Generating rtc.conf
+cat << EOF > ${CONFNAME}
+logger.enable: YES
+logger.log_level: DEBUG
+
+manager.modules.load_path: ${mod_path}
+manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
+
+manager.components.preactivation: SequenceInComponent0
+manager.components.preconnect: \\
+    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
+    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
+    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
+    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
+    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
+    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
+    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
+    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
+    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
+    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+EOF
+
+#############
+# Launch RTC
+${python_cmd} ${comp_path} -f ${CONFNAME}
+
+

--- a/samples/SeqIO/SeqOut.sh
+++ b/samples/SeqIO/SeqOut.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+HOSTNAME="localhost"
+HOSTNAME="140.227.125.181"
+CONFNAME="rtc_SeqOut_${HOSTNAME}.conf"
+COMPNAME="SeqOut.py"
+
+comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
+comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
+
+############################################
+# Check RTC's path
+# RTC's path is set to "comp_path"
+if test "x" = "x$comp3_path" ; then
+    if test "x" = "x$comp2_path" ; then
+	echo "${COMPNAME} not found. Aborting."
+	exit 1
+    else
+	comp_path=${comp2_path}
+	python_cmd="python2"
+    fi
+else
+    comp_path=${comp3_path}
+    python_cmd="python3"
+fi
+
+############################################
+# Check Paho MQTT module
+# Paho MQTT module path is set to "mod_path" 
+if test "xpython3" = "x${python_cmd}" ; then
+    mod3_path=`pip3 show OpenRTM_aist_paho_mqtt_module | grep Location | awk '{print $2;}'`
+    if test "x" = "x${mod3_path}" ; then
+	echo "Paho MQTT module for OpenRTM-aist not found. Aborting."
+	exit 1
+    fi
+    mod_path=${mod3_path}/OpenRTM_aist_paho_mqtt_module
+elif test "xpython2" = "x${python_cmd}" ; then
+    mod2_path=`pip2 show OpenRTM_aist_paho_mqtt_module | grep Location | awk '{print $2;}'`
+    if test "x" = "x${mod2_path}" ; then
+	echo "Paho MQTT module for OpenRTM-aist not found. Aborting."
+	exit 1
+    fi
+    mod_path=${mod2_path}/OpenRTM_aist_paho_mqtt_module
+else
+    echo "Unknown error. (never comes here)"
+    exit 1
+fi
+echo "comp_path: " ${comp_path}
+echo "mod_path:  " ${mod_path}
+
+######################
+# Generating rtc.conf
+cat << EOF > ${CONFNAME}
+logger.enable: YES
+logger.log_level: DEBUG
+
+manager.modules.load_path: ${mod_path}
+manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
+
+manager.components.preactivation: SequenceOutComponent0
+manager.components.preconnect: \\
+    SequenceOutComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
+    SequenceOutComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
+    SequenceOutComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
+    SequenceOutComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
+    SequenceOutComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
+    SequenceOutComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
+    SequenceOutComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
+    SequenceOutComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
+    SequenceOutComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
+    SequenceOutComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+EOF
+
+#############
+# Launch RTC
+${python_cmd} ${comp_path} -f ${CONFNAME}
+
+
+

--- a/samples/SeqIO/SeqOut.sh
+++ b/samples/SeqIO/SeqOut.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-HOSTNAME="140.227.125.181"
 CONFNAME="rtc_SeqOut_${HOSTNAME}.conf"
 COMPNAME="SeqOut.py"
 
@@ -45,6 +44,7 @@ else
     echo "Unknown error. (never comes here)"
     exit 1
 fi
+echo "python:    " ${python_cmd}
 echo "comp_path: " ${comp_path}
 echo "mod_path:  " ${mod_path}
 

--- a/samples/SimpleIO/ConsoleIn.sh
+++ b/samples/SimpleIO/ConsoleIn.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
-COMPNAME="SeqIn.py"
+CONFNAME="rtc_ConsoleIn_${HOSTNAME}.conf"
+COMPNAME="ConsoleIn.py"
 
-comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
-comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
+comp2_path=`dpkg -L openrtm-aist-python-example |grep SimpleIO/${COMPNAME}`
+comp3_path=`dpkg -L openrtm-aist-python3-example |grep SimpleIO/${COMPNAME}`
 
 ############################################
 # Check RTC's path
@@ -57,22 +57,14 @@ logger.log_level: DEBUG
 manager.modules.load_path: ${mod_path}
 manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
 
-manager.components.preactivation: SequenceInComponent0
+manager.components.preactivation: ConsoleIn0
 manager.components.preconnect: \\
-    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
-    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
-    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
-    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
-    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
-    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
-    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
-    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
-    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
-    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+    ConsoleIn0.out?interface_type=paho_mqtt&host=${HOSTNAME}&topic=timedlong
 EOF
 
 #############
 # Launch RTC
 ${python_cmd} ${comp_path} -f ${CONFNAME}
+
 
 

--- a/samples/SimpleIO/ConsoleOut.sh
+++ b/samples/SimpleIO/ConsoleOut.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
-COMPNAME="SeqIn.py"
+CONFNAME="rtc_ConsoleOut_${HOSTNAME}.conf"
+COMPNAME="ConsoleOut.py"
 
-comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
-comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
+comp2_path=`dpkg -L openrtm-aist-python-example |grep SimpleIO/${COMPNAME}`
+comp3_path=`dpkg -L openrtm-aist-python3-example |grep SimpleIO/${COMPNAME}`
 
 ############################################
 # Check RTC's path
@@ -57,18 +57,9 @@ logger.log_level: DEBUG
 manager.modules.load_path: ${mod_path}
 manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
 
-manager.components.preactivation: SequenceInComponent0
+manager.components.preactivation: ConsoleOut0
 manager.components.preconnect: \\
-    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
-    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
-    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
-    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
-    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
-    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
-    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
-    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
-    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
-    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+    ConsoleOut0.in?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long
 EOF
 
 #############

--- a/samples/Slider_and_Motor/Motor.sh
+++ b/samples/Slider_and_Motor/Motor.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
-COMPNAME="SeqIn.py"
+CONFNAME="rtc_TkMotor_${HOSTNAME}.conf"
+COMPNAME="TkMotorComp.py"
 
 comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
 comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
@@ -44,7 +44,7 @@ else
     echo "Unknown error. (never comes here)"
     exit 1
 fi
-echo "python:    " ${python_cmd}
+echo "python:    " ${python_md}
 echo "comp_path: " ${comp_path}
 echo "mod_path:  " ${mod_path}
 
@@ -57,18 +57,9 @@ logger.log_level: DEBUG
 manager.modules.load_path: ${mod_path}
 manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
 
-manager.components.preactivation: SequenceInComponent0
+manager.components.preactivation: TkMotorComp0
 manager.components.preconnect: \\
-    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
-    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
-    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
-    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
-    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
-    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
-    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
-    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
-    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
-    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+    TkMotorComp0.vel?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq
 EOF
 
 #############

--- a/samples/Slider_and_Motor/MotorPos.sh
+++ b/samples/Slider_and_Motor/MotorPos.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
-COMPNAME="SeqIn.py"
+CONFNAME="rtc_TkMotorPos_${HOSTNAME}.conf"
+COMPNAME="TkMotorPosComp.py"
 
 comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
 comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
@@ -44,7 +44,7 @@ else
     echo "Unknown error. (never comes here)"
     exit 1
 fi
-echo "python:    " ${python_cmd}
+echo "python:    " ${python_md}
 echo "comp_path: " ${comp_path}
 echo "mod_path:  " ${mod_path}
 
@@ -57,18 +57,9 @@ logger.log_level: DEBUG
 manager.modules.load_path: ${mod_path}
 manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
 
-manager.components.preactivation: SequenceInComponent0
+manager.components.preactivation: TkMotorPosComp0
 manager.components.preconnect: \\
-    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
-    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
-    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
-    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
-    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
-    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
-    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
-    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
-    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
-    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+    TkMotorPosComp0.pos?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq
 EOF
 
 #############

--- a/samples/Slider_and_Motor/Slider.sh
+++ b/samples/Slider_and_Motor/Slider.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 HOSTNAME="localhost"
-CONFNAME="rtc_SeqIn_${HOSTNAME}.conf"
-COMPNAME="SeqIn.py"
+CONFNAME="rtc_Slider_${HOSTNAME}.conf"
+COMPNAME="SliderComp.py"
 
 comp2_path=`dpkg -L openrtm-aist-python-example |grep ${COMPNAME}`
 comp3_path=`dpkg -L openrtm-aist-python3-example |grep ${COMPNAME}`
@@ -57,22 +57,14 @@ logger.log_level: DEBUG
 manager.modules.load_path: ${mod_path}
 manager.modules.preload: InPortPahoSubscriber.py, OutPortPahoPublisher.py
 
-manager.components.preactivation: SequenceInComponent0
+manager.components.preactivation: SliderComp0
 manager.components.preconnect: \\
-    SequenceInComponent0.Octet?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octet, \\
-    SequenceInComponent0.Short?interface_type=paho_mqtt&host=${HOSTNAME}&topic=short, \\
-    SequenceInComponent0.Long?interface_type=paho_mqtt&host=${HOSTNAME}&topic=long, \\
-    SequenceInComponent0.Float?interface_type=paho_mqtt&host=${HOSTNAME}&topic=float, \\
-    SequenceInComponent0.Double?interface_type=paho_mqtt&host=${HOSTNAME}&topic=double, \\
-    SequenceInComponent0.OctetSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=octetseq, \\
-    SequenceInComponent0.ShortSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=shortseq, \\
-    SequenceInComponent0.LongSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=longseq, \\
-    SequenceInComponent0.FloatSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq, \\
-    SequenceInComponent0.DoubleSeq?interface_type=paho_mqtt&host=${HOSTNAME}&topic=doubleseq
+    SliderComp0.slider?interface_type=paho_mqtt&host=${HOSTNAME}&topic=floatseq
 EOF
 
 #############
 # Launch RTC
 ${python_cmd} ${comp_path} -f ${CONFNAME}
+
 
 


### PR DESCRIPTION
Launch scripts for example RTCs with Paho MQTT interface.
- SimpleIO: ConsoleIn, ConsoleOut
- SeqIO: SeqIn, SeqOut
- Slider and Motor: Slider, Motor, MotorPos
